### PR TITLE
[fix] Add Windows 2022 fix from modflowpy/install-gfortran-action

### DIFF
--- a/.github/actions/compile-windows/action.yml
+++ b/.github/actions/compile-windows/action.yml
@@ -13,6 +13,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # https://github.com/modflowpy/install-gfortran-action/blob/dfc32754e541304f2e7b7ca001e40dce094a5cd6/action.yml#L22-L30
+    - name: Setup gfortran
+      shell: bash
+      run: |
+        FCDIR=/c/ProgramData/Chocolatey/bin
+        LNDIR=/c/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin
+        if [ -d "$FCDIR" ] && [ -f "$LNDIR/libgfortran-5.dll" ] && [ ! -f "$FCDIR/libgfortran-5.dll" ]; then
+            ln -s "$LNDIR/libgfortran-5.dll" "$FCDIR/libgfortran-5.dll"
+        fi
+
     - name: Fetch archive
       id: download
       uses: actions/download-artifact@v3


### PR DESCRIPTION
See https://github.com/modflowpy/install-gfortran-action/blob/dfc32754e541304f2e7b7ca001e40dce094a5cd6/action.yml#L22-L30